### PR TITLE
Config for pragma and jsxRuntime enabling preact

### DIFF
--- a/packages/vite-plugin-react-svg/index.js
+++ b/packages/vite-plugin-react-svg/index.js
@@ -1,8 +1,8 @@
-const { default: svgr } = require('@svgr/core');
+const { transform } = require('@svgr/core');
 const { readFileSync } = require('fs');
 
-async function compileSvg(source, id, options) {
-  const code = await svgr(
+async function compileSvg(source, id, { pragma, ...options }) {
+  const code = await transform(
     source,
     {
       ...options,
@@ -15,6 +15,7 @@ async function compileSvg(source, id, options) {
               '@babel/plugin-transform-react-jsx',
               {
                 useBuiltIns: true,
+                pragma,
               },
             ],
           ],
@@ -40,6 +41,8 @@ module.exports = (options = {}) => {
     replaceAttrValues,
     svgProps,
     titleProp,
+    jsxRuntime,
+    pragma,
   } = options;
 
   const cache = new Map();
@@ -79,6 +82,8 @@ module.exports = (options = {}) => {
               replaceAttrValues,
               svgProps,
               titleProp,
+              jsxRuntime,
+              pragma,
             });
 
             if (isBuild) {

--- a/packages/vite-plugin-react-svg/package.json
+++ b/packages/vite-plugin-react-svg/package.json
@@ -15,9 +15,9 @@
   "author": "Damian Stasik <npm@coded.pl>",
   "dependencies": {
     "@babel/plugin-transform-react-jsx": "^7.14.9",
-    "@svgr/core": "^5.5.0",
-    "@svgr/plugin-jsx": "^5.5.0",
-    "@svgr/plugin-svgo": "^5.5.0"
+    "@svgr/core": "^6.2.1",
+    "@svgr/plugin-jsx": "^6.2.1",
+    "@svgr/plugin-svgo": "^6.2.0"
   },
   "devDependencies": {
     "prettier": "^2.2.1"


### PR DESCRIPTION
Setting the pragma to `h` and the jsxRuntime to `classic-preact` allows this plugin to be used for preact projects.

Example config:
```import { defineConfig } from 'vite'
import preact from '@preact/preset-vite'
import svg from 'vite-plugin-react-svg'

// https://vitejs.dev/config/
export default defineConfig({
  plugins: [
    preact(),
    svg({
      defaultExport: 'component',
      pragma: 'h',
      jsxRuntime: 'classic-preact',
    }),
  ],
})
```